### PR TITLE
Fix typo in yaml extension

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,7 +3,7 @@ module.exports = {
   bracketSpacing: true,
   overrides: [
     {
-      files: ['*.scss', '*.css', '*.yml', '*.yml'],
+      files: ['*.scss', '*.css', '*.yaml', '*.yml'],
       options: {
         singleQuote: false,
         tabWidth: 4


### PR DESCRIPTION
There was 2 times the same yml extension. I guess you meant to use yaml and yml